### PR TITLE
Update ai.md

### DIFF
--- a/official/docs/services/ai.md
+++ b/official/docs/services/ai.md
@@ -2,7 +2,7 @@
 
 ## Ollama
 - 从[官网](https://ollama.com/)下载安装 ollama 
-- OLLAMA_ORIGINS="*" ollama serve （允许跨域访问并启动ollama）
+- 在控制面板-系统属性-环境变量-用户环境变量新建变量名"OLLAMA_HOST"变量值"0.0.0.0",变量名"OLLAMA_ORIGINS"变量值"*"
 - 进入插件的[设置页](https://dash.immersivetranslate.com/#general),翻译服务选择 openAI
     - api_key: ollama
     - 自定义模型: llama2 、[other models](https://ollama.com/library)


### PR DESCRIPTION
The original environment variables in the document only mention adding OLLAMA_ORIGINS ="*" without mentioning that you also need to add OLLAMA_HOST="0.0.0.0", which prevents Immersive Translation from normalizing access to the Ollama API. 
原文档里面配置环境变量只提到需要添加OLLAMA_ORIGINS="*"，未提到还需要添加OLLAMA_HOST="0.0.0.0"，导致无法让沉浸式翻译正常接入Ollama API